### PR TITLE
Refine documentation for clarity and consistency

### DIFF
--- a/MASTER_DOCUMENTATION.md
+++ b/MASTER_DOCUMENTATION.md
@@ -137,7 +137,7 @@ O Sistema Guardião emprega um conjunto diversificado de protocolos de comunica�
 O `GuardianCentralOrchestrator` é o cérebro estratégico do Sistema Guardião. Seu fluxo de dados e processo decisório são complexos e iterativos:
 
 1.  **Ingestão de Eventos e Inteligência:**
-    *   Recebe fluxos contínuos de eventos, alertas e dados processados dos cinco subsistemas (CURUPIRA, IARA, SACI, BOITATÁ, ANHANGÁ) via tópicos dedicados no Kafka.
+    *   Recebe fluxos contínuos de eventos, alertas e dados processados dos cinco subsistemas (CURUPIRA, IARA, SACI, BOITATÁ, ANHANGÁ) via tópicos dedicados no Kafka. Esses eventos são padronizados (por exemplo, como objetos ThreatEvent, conforme definido em `guardian_orchestrator.py`) e podem incluir detalhes granulares como `origin_sensor_id` para rastreabilidade precisa da origem do dado.
     *   Consome dados de fontes externas (meteorologia, inteligência de ameaças globais, dados governamentais) através de adaptadores específicos.
 
 2.  **Enriquecimento e Contextualização:**

--- a/docs/SACI_MVP_SPECIFICATION.md
+++ b/docs/SACI_MVP_SPECIFICATION.md
@@ -37,6 +37,11 @@ Power_Management:
   low_power_mode: "Deep sleep <10µA"
   
 Sensor_Array:
+  # NOTE: The currently implemented MVP firmware (src/hardware/esp32/saci_sensor_node.py)
+  # primarily utilizes the DHT22 for temperature/humidity and an analog gas sensor
+  # (like MQ-2 or MQ-135, referred to as MQ-2 in this section's original list) for air quality/smoke.
+  # The sensors listed below represent the full planned specification for the SACI node
+  # or future MVP iterations. The initial MVP focuses on core fire detection capabilities.
   temperature_humidity: "DHT22"
   smoke_detection: "MQ-2 gas sensor" 
   co2_measurement: "MH-Z19B NDIR"

--- a/sistema_guardiao_c4_diagrams.html
+++ b/sistema_guardiao_c4_diagrams.html
@@ -385,6 +385,7 @@
                     class LLMService,MLPipeline,VectorStore,ReinforcementLearning aiTool
                     class SensorNetwork,ExternalAPIs,HistoricalData dataSource
             </div>
+            <p class="diagram-caption"><strong>Note on AI Agent Roles:</strong> The agents listed such as 'EnviroAgent' and 'LogisticsAgent' represent internal functional specializations within the GuardianCentralOrchestrator's AI crew. These specialized agents support the primary five folklore-named subsystems (CURUPIRA, IARA, SACI, BOITATÁ, ANHANGÁ) by handling specific domains of analysis and task execution. For example, EnviroAgent might provide detailed environmental impact assessments for SACI's fire predictions or BOITATÁ's infrastructure projects, while LogisticsAgent could assist IARA with medical supply chain optimization or ANHANGÁ with resource deployment for communication infrastructure. They can also represent capabilities that might evolve into future, more specialized subsystems.</p>
         </div>
 
         <!-- C3: Component Diagram - CURUPIRA Subsystem -->

--- a/src/saci_mvp/README.md
+++ b/src/saci_mvp/README.md
@@ -121,6 +121,9 @@ LOG_LEVEL=INFO
 ## 📡 HARDWARE - ESP32 SENSOR NODE
 
 ### Componentes Necessários
+
+**Nota sobre Sensores MVP:** A implementação atual do firmware MVP (conforme `src/hardware/esp32/saci_sensor_node.py`) foca nos sensores DHT22 (temperatura/umidade) e MQ-135/MQ-2 (gases/fumaça). A lista abaixo representa a especificação completa planejada para o nó SACI ou iterações futuras do MVP, visando expandir as capacidades de monitoramento ambiental.
+
 | Componente | Modelo | Função | Preço Estimado |
 |------------|--------|--------|----------------|
 | Microcontrolador | ESP32-WROOM-32 | Processamento principal | R$ 35 |


### PR DESCRIPTION
This commit addresses several documentation inconsistencies and adds clarifications:

1.  **SACI MVP Sensor Scope:**
    *   Updated `docs/SACI_MVP_SPECIFICATION.md` (section 2.1) and `src/saci_mvp/README.md` (Hardware section) to clarify that the current MVP firmware uses DHT22 and MQ-2/MQ-135 sensors.
    *   Noted that other sensors listed (MH-Z19B, BH1750, YL-69, BMP280, wind sensors) are part of the planned full specification or future MVP iterations.

2.  **Orchestrator AI Agent Roles:**
    *   Added a note to the C3 diagram for "Agentic AI Orchestrator" in `sistema_guardiao_c4_diagrams.html`.
    *   The note clarifies that agent roles like "EnviroAgent" and "LogisticsAgent" are internal functional specializations within the GuardianCentralOrchestrator's AI crew, supporting the five main subsystems or representing future expansions.

3.  **ThreatEvent Origin in MASTER_DOCUMENTATION.md:**
    *   Refined the "GuardianCentralOrchestrator: Fluxo de Dados e Decisão" section, step 1 "Ingestão de Eventos e Inteligência".
    *   Added clarification that incoming events from subsystems are standardized (e.g., as ThreatEvent objects defined in `guardian_orchestrator.py`) and can include details like `origin_sensor_id` for precise traceability.